### PR TITLE
replace alphagov org with govwifi in docs urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ N.B. The private GovWifi [build repository][build-repo] contains instructions on
 
 ## Table of Contents
 
-* [Overview](#overview)
-  * [Sinatra routes](#sinatra-routes)
-  * [Dependencies](#dependencies)
-* [Developing](#developing)
-  * [Deploying changes](#deploying-changes)
-* [Gotchas](#gotchas)
-  * [Extra API parameters](#extra-API-parameters)
-* [Licence](#licence)
+- [GovWifi Authentication API](#govwifi-authentication-api)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Sinatra routes](#sinatra-routes)
+    - [Dependencies](#dependencies)
+  - [Developing](#developing)
+    - [Deploying changes](#deploying-changes)
+  - [Gotchas](#gotchas)
+    - [Extra API parameters](#extra-api-parameters)
+  - [Licence](#licence)
 
 ## Overview
 
@@ -61,6 +63,6 @@ CloudWatch logs is useful for linking up matching requests between the
 This codebase is released under [the MIT License][mit].
 
 [mit]: LICENCE
-[build-repo]:https://github.com/alphagov/govwifi-build
-[user-signup-api]: https://github.com/alphagov/govwifi-user-signup-api/pull/33
-[makefile]: https://github.com/alphagov/govwifi-authentication-api/blob/master/Makefile
+[build-repo]:https://github.com/GovWifi/govwifi-build
+[user-signup-api]: https://github.com/GovWifi/govwifi-user-signup-api/pull/33
+[makefile]: https://github.com/GovWifi/govwifi-authentication-api/blob/master/Makefile


### PR DESCRIPTION
### What
Update our docs to reflect changes in GDS repos

### Why
We must keep our docs up to date and accurate

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-2341
